### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master, develop]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ANicholasson/simple-csv-js/security/code-scanning/3](https://github.com/ANicholasson/simple-csv-js/security/code-scanning/3)

To fix the issue, we should add an explicit `permissions` block to the workflow YAML file. Since none of the job steps require write access to the repository or other areas, setting `contents: read` at the root of the workflow (before `jobs:`) will restrict the workflow's GITHUB_TOKEN to read-only repository contents access, implementing the principle of least privilege. This change should be added at the top level, typically right after the `name:` and `on:` sections and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add explicit read-only permissions to the test workflow to restrict GITHUB_TOKEN scope.
> 
> - **CI / GitHub Actions**:
>   - Add explicit `permissions` block in `.github/workflows/test.yml` with `contents: read` to restrict the workflow token scope.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0c74d170b7afd75daa1f62089683efb89190bc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->